### PR TITLE
feat: fixed reservation in massif header for peak stack

### DIFF
--- a/massifs/logformat_test.go
+++ b/massifs/logformat_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMassifLogEntries(t *testing.T) {
+func TestMassifLogEntriesV0(t *testing.T) {
 
 	// Working with height 1 massifs and the following overall MMR
 	//
@@ -110,7 +110,113 @@ func TestMassifLogEntries(t *testing.T) {
 					// underlying primitives we want to cover.
 					dataLen := int(trieDataEnd + stackLens[massifIndex]*32 + massifNodeIndex*32)
 
-					nodeCount, err := MassifLogEntries(dataLen, massifIndex, uint8(massifHeight))
+					nodeCount, err := MassifLogEntriesV0(dataLen, massifIndex, uint8(massifHeight))
+					if massifNodeIndex < 0 {
+						if !errors.Is(err, ErrMassifDataLengthInvalid) {
+							t.Errorf("expected err %v, got %v", ErrBeforeFirstLeaf, err)
+						}
+					} else {
+						assert.NoError(t, err)
+
+						assert.Equal(t, nodeCount, uint64(massifNodeIndex))
+					}
+				}
+			}
+			// if end offset or start offset are negative we should get an error
+		})
+	}
+}
+
+func TestMassifLogEntriesV1(t *testing.T) {
+
+	// Working with height 1 massifs and the following overall MMR
+	//
+	//  4                        30
+	//
+	//
+	//               14                        29
+	//	3           /  \                      /   \
+	//	           /    \                    /     \
+	//	          /      \                  /       \
+	//	         /        \                /         \
+	//	2      6 .      .  13             21          28
+	//	      /   \       /   \          /  \        /   \
+	//	1    2  |  5  |  9  |  12   |  17  | 20   | 24   | 27   |  --- massif tree line massif height = 1
+	//	    / \ |/  \ | / \ |  /  \ | /  \ | / \  | / \  | / \  |
+	//	   0   1|3   4|7   8|10   11|15  16|18  19|22  23|25  26| MMR INDICES
+	//     -----|-----|-----|-------|------|------|------|------|
+	//	   0 . 1|2 . 3|4   5| 6    7| 8   9|10  11|12  13|14  15| LEAF INDICES
+	//     -----|-----|-----|-------|------|------|------|------|
+	//       0  |  1  |  2  |  3    |   4  |   5  |   6  |   7  | MASSIF INDICES
+	//     -----|-----|-----|-------|------|------|------|------|
+
+	// I think it is sufficient to do this just for one massifHeight, but we could extend this approach.
+	massifHeight := uint64(2) // each masif has 2 leaves and 3 nodes + spur
+	massifNodeCount := uint64(2<<massifHeight - 1)
+	massifLeafCount := (massifNodeCount + 1) / 2
+	trieDataSize := 64 * massifLeafCount
+
+	tests := []struct {
+		name        string
+		startOffset int64
+		endOffset   int64
+		want        uint64
+	}{
+		{
+			name:        "underflow and over flow",
+			startOffset: -1,
+			endOffset:   -1,
+		},
+		{
+			name:        "full but correct range",
+			startOffset: 0,
+			endOffset:   0,
+		},
+	}
+
+	// This aligns with the constants in logformat.go. it is purposefully defined
+	// here explicitly so we reconsider this test if the constants change.
+	// ValueBytes * 8 + IndexHeaderBytes + TrieEntryBytes * leafCount
+	fixedHeaderEnd := uint64(32*7 + 32)
+
+	// these are mostly not worth their own unit tests and are very easy to
+	// check here. and having these guards here model the co-dependence on the
+	// primitives for finding the right bits of the format.
+	gotFixedHeaderEnd := FixedHeaderEnd()
+	assert.Equal(t, fixedHeaderEnd, gotFixedHeaderEnd)
+
+	gotTrieDataSize := TrieDataSize(uint8(massifHeight))
+	assert.Equal(t, trieDataSize, gotTrieDataSize)
+
+	trieDataEnd := int64(fixedHeaderEnd + 32 + trieDataSize)
+
+	gotTrieDataEnd := TrieDataEnd(uint8(massifHeight))
+	assert.Equal(t, trieDataEnd, int64(gotTrieDataEnd))
+
+	// This tests that all *valid* mmr data lengths
+	/* */
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			for massifIndex := range uint64(8) {
+
+				// each blob has a varying (but computable) number of mmr nodes.
+				// massif height just determines how many *leaves* are in a full
+				// blob.. and the leaf count is constant for all blobs. The back
+				// fill nodes required for each blobs 'last' leaf varies.
+				firstIndex := mmr.MMRIndex(massifLeafCount * massifIndex)
+				lastIndex := mmr.MMRIndex(massifLeafCount*(massifIndex+1)) - 1
+				expectNodeCount := lastIndex - firstIndex + 1
+
+				// for each massif try a range of log sizes. the sizes can be invalid if the startOffset or endOffset are negative.
+				for massifNodeIndex := 0 + tt.startOffset; massifNodeIndex < int64(expectNodeCount)-tt.endOffset; massifNodeIndex++ {
+
+					// we use a lookup table to define the expected peak stack
+					// lengths so this test doesn't overly rely on the
+					// underlying primitives we want to cover.
+					dataLen := int(trieDataEnd + MaxMMRHeight*32 + massifNodeIndex*32)
+
+					nodeCount, err := MassifLogEntries(dataLen, uint8(massifHeight))
 					if massifNodeIndex < 0 {
 						if !errors.Is(err, ErrMassifDataLengthInvalid) {
 							t.Errorf("expected err %v, got %v", ErrBeforeFirstLeaf, err)

--- a/massifs/massifappendcontext.go
+++ b/massifs/massifappendcontext.go
@@ -107,6 +107,12 @@ func CreateFirstMassifContext(ctx context.Context, epoch uint32, massifHeight ui
 	data = append(data, mc.InitIndexData()...)
 	mc.Data = data
 
+	if mc.Start.Version > 0 {
+		// Pad the fixed allocation with zero bytes
+		padBytes := make([]byte, MaxMMRHeight*ValueBytes-(mc.Start.PeakStackLen*ValueBytes))
+		mc.Data = append(mc.Data, padBytes...)
+	}
+
 	// Create peak stack map for sequencers that need it
 	if err := mc.CreatePeakStackMap(); err != nil {
 		return MassifContext{}, fmt.Errorf("failed to create peak stack map for first massif: %w", err)

--- a/massifs/massifstart.go
+++ b/massifs/massifstart.go
@@ -86,7 +86,7 @@ const (
 	// - a fixed 64 entries are always reserved for the peak stack, regardless of how many are
 	//   actually needed. this makes it possible to trivially compute the node &
 	//   leaf counts knowing only the byte size of the massif and assuming the
-	//   version is >= 2
+    //   version is >= 1
 )
 
 var (

--- a/massifs/massifstart.go
+++ b/massifs/massifstart.go
@@ -48,7 +48,7 @@ const (
 	//
 	// .         | reserved | idtimestamp| reserved |  version | epoch  |massif height| massif i |
 	// .         | 0        | 8        15|          |  21 - 22 | 23   26|27         27| 28 -  31 |
-	// bytes     | 1        |     8      |          |      2   |    4   |      1      |     4    |
+	// bytes     | 1        |     8      |     5    |      2   |    4   |      1      |     4    |
 	//
 	// Note this layout produces a sequentially valued key. The value is always
 	// considered as a big endian large integer. Lexical ordering is defined
@@ -79,8 +79,14 @@ const (
 	MassifStartKeyMassifEnd           = MassifStartKeyMassifFirstByte + MassifStartKeyMassifSize // 32 bit
 	MassifStartKeyFirstIndexFirstByte = MassifStartKeyMassifEnd
 
-	MassifCurrentVersion = uint16(0)
 	Epoch2038            = uint32(1)
+	MassifCurrentVersion = uint16(1)
+	// Version 0 was/is produced by the datatrails implementation, currently operated by OnID
+	// Version 2 introduces:
+	// - a fixed 64 entries are always reserved for the peak stack, regardless of how many are
+	//   actually needed. this makes it possible to trivially compute the node &
+	//   leaf counts knowing only the byte size of the massif and assuming the
+	//   version is >= 2
 )
 
 var (

--- a/massifs/rootsigner.go
+++ b/massifs/rootsigner.go
@@ -84,7 +84,7 @@ type MMRState struct {
 	IDTimestamp uint64 `cbor:"4,keyasint"`
 
 	// The current idtimestamp epoch (~17 year cadence. We use the unix epoch as
-	// our base but roll twice as fast. so we are on epoch 1 in 2024)
+	// our base but roll twice as fast. so we are on epoch 1 until 2038)
 	CommitmentEpoch uint32 `cbor:"6,keyasint"`
 }
 


### PR DESCRIPTION
So that the node count can be computed from the massif data size directly (assuming the v1 format)