### PR TITLE
feat(massifs): add SetTrieEntryExtra with variadic extraBytes support

### DIFF
--- a/massifs/trieentry_test.go
+++ b/massifs/trieentry_test.go
@@ -202,6 +202,240 @@ func TestSetLogIndexEntry(t *testing.T) {
 			if tt.args.extraBytes != nil {
 				assert.Equal(t, tt.args.extraBytes[0:24], gotBytes)
 			}
+
+			// Test equivalence with SetTrieEntryExtra when only one extraBytes slice is provided
+			// Reset the data to original state
+			copy(tt.args.logData, slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four))
+			got = GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, got, tt.args.index)
+
+			// Use SetTrieEntryExtra with single extraBytes slice
+			if tt.args.extraBytes != nil {
+				SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear, tt.args.extraBytes)
+			} else {
+				SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear)
+			}
+
+			// Verify results match SetTrieEntry
+			gotBeforeExtra := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex-1)
+			assert.Equal(t, tt.args.before, gotBeforeExtra)
+			gotAfterExtra := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex+1)
+			assert.Equal(t, tt.args.after, gotAfterExtra)
+
+			gotExtra := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, b64clear[:32], gotExtra)
+
+			gotIDExtra := GetIdtimestamp(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, tt.args.idTimestamp, binary.BigEndian.Uint64(gotIDExtra))
+
+			gotBytesExtra := GetExtraBytes(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, 24, len(gotBytesExtra))
+
+			if tt.args.extraBytes != nil {
+				assert.Equal(t, tt.args.extraBytes[0:24], gotBytesExtra)
+			}
+		})
+	}
+}
+
+func TestSetTrieEntryExtra(t *testing.T) {
+	expectTrieEntryBytes := 64
+
+	// If this fails, then we are likely updating the index format and this test needs updating.
+	require.Equal(t, expectTrieEntryBytes, TrieEntryBytes)
+
+	b64clear := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	b64h0 := []byte{0, 0, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0}
+	b64h1 := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 0}
+	b64zero := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
+	b64one := []byte{1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}
+	b64two := []byte{2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2}
+	b64three := []byte{3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}
+	b64four := []byte{4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
+
+	// Test data for extended extra bytes
+	extraBytes0 := make([]byte, 24)
+	for i := range extraBytes0 {
+		extraBytes0[i] = byte(0xAA + i)
+	}
+	extraBytes1 := make([]byte, 32)
+	for i := range extraBytes1 {
+		extraBytes1[i] = byte(0xBB + i)
+	}
+	extraBytes2 := make([]byte, 32)
+	for i := range extraBytes2 {
+		extraBytes2[i] = byte(0xCC + i)
+	}
+	extraBytes3 := make([]byte, 32) // This should be ignored
+	for i := range extraBytes3 {
+		extraBytes3[i] = byte(0xDD + i)
+	}
+
+	type args struct {
+		logData     []byte
+		indexStart  uint64
+		leafIndex   uint64
+		idTimestamp uint64
+		trieKey     []byte
+		extraBytes  [][]byte
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantExtraBytes [][]byte // Expected extra bytes at each location
+		verifyExtended bool     // Whether to verify extended locations
+	}{
+		{
+			name: "zero extraBytes",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1,
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  nil,
+			},
+			wantExtraBytes: nil,
+			verifyExtended: false,
+		},
+		{
+			name: "one extraBytes",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1,
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{extraBytes0},
+			},
+			wantExtraBytes: [][]byte{extraBytes0},
+			verifyExtended: false,
+		},
+		{
+			name: "two extraBytes",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1, // Extended bytes write to index 1*2=2
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{extraBytes0, extraBytes1},
+			},
+			wantExtraBytes: [][]byte{extraBytes0, extraBytes1},
+			verifyExtended: true,
+		},
+		{
+			name: "three extraBytes",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1, // Extended bytes write to index 1*2=2
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{extraBytes0, extraBytes1, extraBytes2},
+			},
+			wantExtraBytes: [][]byte{extraBytes0, extraBytes1, extraBytes2},
+			verifyExtended: true,
+		},
+		{
+			name: "more than three extraBytes (should ignore extras)",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1, // Extended bytes write to index 1*2=2
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{extraBytes0, extraBytes1, extraBytes2, extraBytes3},
+			},
+			wantExtraBytes: [][]byte{extraBytes0, extraBytes1, extraBytes2}, // extraBytes3 should be ignored
+			verifyExtended: true,
+		},
+		{
+			name: "nil extraBytes[0] with extended bytes (skip standard field)",
+			args: args{
+				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
+				indexStart:  uint64(expectTrieEntryBytes * 2),
+				leafIndex:   1, // Extended bytes write to index 1*2=2
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{nil, extraBytes1, extraBytes2}, // nil for [0], write only extended
+			},
+			wantExtraBytes: [][]byte{nil, extraBytes1, extraBytes2}, // nil means don't write standard field
+			verifyExtended: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Determine expected initial key based on leafIndex
+			var expectedInitialKey []byte
+			if tt.args.leafIndex == 0 {
+				expectedInitialKey = b64zero[:32]
+			} else {
+				expectedInitialKey = b64one[:32]
+			}
+
+			// Verify initial state
+			got := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, expectedInitialKey, got)
+
+			// Capture original extra bytes if we're testing nil case
+			var originalExtraBytes []byte
+			if len(tt.wantExtraBytes) > 0 && tt.wantExtraBytes[0] == nil {
+				originalExtraBytes = make([]byte, 24)
+				copy(originalExtraBytes, GetExtraBytes(tt.args.logData, tt.args.indexStart, tt.args.leafIndex))
+			}
+
+			// Call SetTrieEntryExtra
+			SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, tt.args.trieKey, tt.args.extraBytes...)
+
+			// Verify trieKey at the main entry
+			got = GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, tt.args.trieKey, got)
+
+			// Verify idTimestamp at the main entry
+			gotID := GetIdtimestamp(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, tt.args.idTimestamp, binary.BigEndian.Uint64(gotID))
+
+			// Verify standard extra bytes field at the main entry
+			gotBytes := GetExtraBytes(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			assert.Equal(t, 24, len(gotBytes))
+			if len(tt.wantExtraBytes) > 0 && tt.wantExtraBytes[0] != nil {
+				assert.Equal(t, tt.wantExtraBytes[0][:24], gotBytes)
+			} else if len(tt.wantExtraBytes) > 0 && tt.wantExtraBytes[0] == nil {
+				// If extraBytes[0] is nil, the standard field should remain unchanged
+				assert.Equal(t, originalExtraBytes, gotBytes)
+			}
+
+			// Verify extended extra bytes fields if applicable
+			// Note: Extended bytes are written at trieIndex*2, which will overwrite that entry
+			if tt.verifyExtended && len(tt.wantExtraBytes) > 1 {
+				trieEntryXOffset := TrieEntryOffset(tt.args.indexStart, tt.args.leafIndex*2)
+				if tt.wantExtraBytes[1] != nil {
+					gotExtended1 := tt.args.logData[trieEntryXOffset : trieEntryXOffset+ValueBytes]
+					assert.Equal(t, tt.wantExtraBytes[1][:32], gotExtended1)
+				}
+
+				if len(tt.wantExtraBytes) > 2 && tt.wantExtraBytes[2] != nil {
+					gotExtended2 := tt.args.logData[trieEntryXOffset+ValueBytes : trieEntryXOffset+ValueBytes*2]
+					assert.Equal(t, tt.wantExtraBytes[2][:32], gotExtended2)
+				}
+			}
+
+			// Verify adjacent entries are not corrupted
+			// The entry at trieIndex*2 will be overwritten by extended bytes, so we don't check it
+			gotBefore := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex-1)
+			if tt.args.leafIndex-1 == 0 {
+				assert.Equal(t, b64zero[:32], gotBefore)
+			} else {
+				assert.Equal(t, b64one[:32], gotBefore)
+			}
+
+			// Check entry after, but skip if it's the one being overwritten by extended bytes
+			if !tt.verifyExtended || tt.args.leafIndex*2 != tt.args.leafIndex+1 {
+				gotAfter := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex+1)
+				assert.Equal(t, b64two[:32], gotAfter)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Add SetTrieEntryExtra function that extends SetTrieEntry with support for up to 3 variadic extraBytes slices. This utilizes the extra space reserved in the index format that was originally allocated due to a bug in TrieDataEnd (logformat.go:93-99), which is now part of the formal format specification.

The function handles extraBytes as follows:
- First 24 bytes of extraBytes[0] are written to the standard extra bytes field (TrieEntryExtraBytesStart) if extraBytes[0] is not nil
- If extraBytes[1] is provided and not nil, 32 bytes are written starting at TrieEntryOffset(indexStart, trieIndex * 2)
- If extraBytes[2] is provided and not nil, 32 bytes are written starting at TrieEntryOffset(indexStart, trieIndex * 2) + ValueBytes
- Any nil extraBytes elements are silently ignored, allowing callers to skip any element they don't want to write (e.g., pass nil for extraBytes[0] to write only extended bytes)
- Additional extraBytes elements beyond the third are silently ignored

The implementation includes:
- Comprehensive documentation referencing the format specification
- Full test coverage for all cases (0, 1, 2, 3, and >3 extraBytes)
- Test case demonstrating nil extraBytes[0] with extended bytes to verify nil elements are properly ignored
- Equivalence tests demonstrating backward compatibility with SetTrieEntry when only one extraBytes slice is provided
- Verification that adjacent entries are not corrupted (except where extended bytes intentionally overwrite entries at trieIndex*2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce SetTrieEntryExtra to write trie entries with up to 3 extra byte slices (including extended fields) and add comprehensive tests covering behavior and backward compatibility.
> 
> - **massifs**
>   - **`massifs/trieentry.go`**:
>     - Add `SetTrieEntryExtra(...)` to write `trieKey` and `idTimestamp` plus up to 3 extra-byte slices.
>       - Writes first 24 bytes to standard `extraBytes` field.
>       - Writes optional 32-byte extended blocks at `TrieEntryOffset(indexStart, trieIndex*2)` and `+ ValueBytes`.
>       - Ignores `nil` entries and any beyond the third.
>     - Inline docs clarify format/spec and extended storage.
>   - **Tests**:
>     - Extend `TestSetLogIndexEntry` to verify equivalence with `SetTrieEntryExtra` when using a single `extraBytes` slice.
>     - Add `TestSetTrieEntryExtra` covering 0/1/2/3/>3 `extraBytes`, `nil` handling, extended offsets, and adjacency integrity.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c4a1f56e38a6176a7c234726d57f73671588531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->