### PR TITLE
fix(massifs): prevent extended bytes from overwriting entry when triIndex is 0

### DIFF
--- a/massifs/massifcontext.go
+++ b/massifs/massifcontext.go
@@ -402,7 +402,7 @@ func (mc *MassifContext) AddHashedLeaf(
 	// Overwrite the pre-allocated index entry with the index data.
 	// Combine extraBytes0 with variadic extraBytes for SetTrieEntryExtra
 	allExtraBytes := append([][]byte{extraBytes0}, extraBytes...)
-	SetTrieEntryExtra(mc.Data, mc.IndexStart(), nextLeafIndex, idTimestamp, trieKey, allExtraBytes...)
+	SetTrieEntryExtra(mc.Start.MassifHeight, mc.Data, mc.IndexStart(), nextLeafIndex, idTimestamp, trieKey, allExtraBytes...)
 
 	// Save the last id added so that we can guarantee monotonicity (and hence uniqueness for the tenant)
 	mc.setLastIDTimestamp(idTimestamp)

--- a/massifs/trieentry_test.go
+++ b/massifs/trieentry_test.go
@@ -210,10 +210,12 @@ func TestSetLogIndexEntry(t *testing.T) {
 			assert.Equal(t, got, tt.args.index)
 
 			// Use SetTrieEntryExtra with single extraBytes slice
+			// Use massifHeight 3 (8 entries) to accommodate test indices up to 4
+			massifHeight := uint8(3)
 			if tt.args.extraBytes != nil {
-				SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear, tt.args.extraBytes)
+				SetTrieEntryExtra(massifHeight, tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear, tt.args.extraBytes)
 			} else {
-				SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear)
+				SetTrieEntryExtra(massifHeight, tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, b64clear)
 			}
 
 			// Verify results match SetTrieEntry
@@ -253,6 +255,25 @@ func TestSetTrieEntryExtra(t *testing.T) {
 	b64three := []byte{3, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3}
 	b64four := []byte{4, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 4}
 
+	// Create test data large enough to accommodate extended storage
+	// With massifHeight 3, we have 8 entries (512 bytes) + extended storage (512 bytes) = 1024 bytes
+	// indexStart is at 128, so we need at least 128 + 1024 = 1152 bytes
+	// For entry at index 4 with extended bytes[2]: offset = 128 + 4*64 + 512 + 64 = 960, so we need at least 1024 bytes
+	massifHeight := uint8(3)
+	trieDataSize := TrieDataSize(massifHeight) // 8 * 64 = 512
+	extendedStorageSize := trieDataSize        // Extended storage is same size as trie data
+	totalTrieAreaSize := trieDataSize + extendedStorageSize
+	indexStart := uint64(expectTrieEntryBytes * 2) // 128
+	requiredSize := indexStart + totalTrieAreaSize // 128 + 1024 = 1152
+
+	// Create base test data template
+	baseDataTemplate := slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four)
+	padSize := int(requiredSize) - len(baseDataTemplate)
+	var pad []byte
+	if padSize > 0 {
+		pad = make([]byte, padSize)
+	}
+
 	// Test data for extended extra bytes
 	extraBytes0 := make([]byte, 24)
 	for i := range extraBytes0 {
@@ -288,8 +309,8 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "zero extraBytes",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
 				leafIndex:   1,
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
@@ -301,8 +322,8 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "one extraBytes",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
 				leafIndex:   1,
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
@@ -314,9 +335,9 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "two extraBytes",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
-				leafIndex:   1, // Extended bytes write to index 1*2=2
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
+				leafIndex:   1, // Extended bytes written to extended storage area at trieEntryOffset + TrieDataSize
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
 				extraBytes:  [][]byte{extraBytes0, extraBytes1},
@@ -327,9 +348,9 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "three extraBytes",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
-				leafIndex:   1, // Extended bytes write to index 1*2=2
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
+				leafIndex:   1, // Extended bytes written to extended storage area at trieEntryOffset + TrieDataSize
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
 				extraBytes:  [][]byte{extraBytes0, extraBytes1, extraBytes2},
@@ -340,9 +361,9 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "more than three extraBytes (should ignore extras)",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
-				leafIndex:   1, // Extended bytes write to index 1*2=2
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
+				leafIndex:   1, // Extended bytes written to extended storage area at trieEntryOffset + TrieDataSize
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
 				extraBytes:  [][]byte{extraBytes0, extraBytes1, extraBytes2, extraBytes3},
@@ -353,9 +374,9 @@ func TestSetTrieEntryExtra(t *testing.T) {
 		{
 			name: "nil extraBytes[0] with extended bytes (skip standard field)",
 			args: args{
-				logData:     slices.Concat(b64h0, b64h1, b64zero, b64one, b64two, b64three, b64four),
-				indexStart:  uint64(expectTrieEntryBytes * 2),
-				leafIndex:   1, // Extended bytes write to index 1*2=2
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
+				leafIndex:   1, // Extended bytes written to extended storage area at trieEntryOffset + TrieDataSize
 				idTimestamp: 0x0102030405060708,
 				trieKey:     b64clear[:32],
 				extraBytes:  [][]byte{nil, extraBytes1, extraBytes2}, // nil for [0], write only extended
@@ -363,10 +384,27 @@ func TestSetTrieEntryExtra(t *testing.T) {
 			wantExtraBytes: [][]byte{nil, extraBytes1, extraBytes2}, // nil means don't write standard field
 			verifyExtended: true,
 		},
+		{
+			name: "trieIndex 0 with extended bytes (fixes bug where index 0 would overwrite entry)",
+			args: args{
+				logData:     slices.Concat(baseDataTemplate, pad),
+				indexStart:  indexStart,
+				leafIndex:   0, // Extended bytes written to extended storage area at trieEntryOffset + TrieDataSize
+				idTimestamp: 0x0102030405060708,
+				trieKey:     b64clear[:32],
+				extraBytes:  [][]byte{extraBytes0, extraBytes1, extraBytes2},
+			},
+			wantExtraBytes: [][]byte{extraBytes0, extraBytes1, extraBytes2},
+			verifyExtended: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh copy of the test data for each test to avoid cross-test contamination
+			testData := make([]byte, len(tt.args.logData))
+			copy(testData, tt.args.logData)
+
 			// Determine expected initial key based on leafIndex
 			var expectedInitialKey []byte
 			if tt.args.leafIndex == 0 {
@@ -376,29 +414,29 @@ func TestSetTrieEntryExtra(t *testing.T) {
 			}
 
 			// Verify initial state
-			got := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			got := GetTrieKey(testData, tt.args.indexStart, tt.args.leafIndex)
 			assert.Equal(t, expectedInitialKey, got)
 
 			// Capture original extra bytes if we're testing nil case
 			var originalExtraBytes []byte
 			if len(tt.wantExtraBytes) > 0 && tt.wantExtraBytes[0] == nil {
 				originalExtraBytes = make([]byte, 24)
-				copy(originalExtraBytes, GetExtraBytes(tt.args.logData, tt.args.indexStart, tt.args.leafIndex))
+				copy(originalExtraBytes, GetExtraBytes(testData, tt.args.indexStart, tt.args.leafIndex))
 			}
 
 			// Call SetTrieEntryExtra
-			SetTrieEntryExtra(tt.args.logData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, tt.args.trieKey, tt.args.extraBytes...)
+			SetTrieEntryExtra(massifHeight, testData, tt.args.indexStart, tt.args.leafIndex, tt.args.idTimestamp, tt.args.trieKey, tt.args.extraBytes...)
 
 			// Verify trieKey at the main entry
-			got = GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			got = GetTrieKey(testData, tt.args.indexStart, tt.args.leafIndex)
 			assert.Equal(t, tt.args.trieKey, got)
 
 			// Verify idTimestamp at the main entry
-			gotID := GetIdtimestamp(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			gotID := GetIdtimestamp(testData, tt.args.indexStart, tt.args.leafIndex)
 			assert.Equal(t, tt.args.idTimestamp, binary.BigEndian.Uint64(gotID))
 
 			// Verify standard extra bytes field at the main entry
-			gotBytes := GetExtraBytes(tt.args.logData, tt.args.indexStart, tt.args.leafIndex)
+			gotBytes := GetExtraBytes(testData, tt.args.indexStart, tt.args.leafIndex)
 			assert.Equal(t, 24, len(gotBytes))
 			if len(tt.wantExtraBytes) > 0 && tt.wantExtraBytes[0] != nil {
 				assert.Equal(t, tt.wantExtraBytes[0][:24], gotBytes)
@@ -408,34 +446,42 @@ func TestSetTrieEntryExtra(t *testing.T) {
 			}
 
 			// Verify extended extra bytes fields if applicable
-			// Note: Extended bytes are written at trieIndex*2, which will overwrite that entry
+			// Extended bytes are written to the extended storage area at trieEntryOffset + TrieDataSize
 			if tt.verifyExtended && len(tt.wantExtraBytes) > 1 {
-				trieEntryXOffset := TrieEntryOffset(tt.args.indexStart, tt.args.leafIndex*2)
+				trieEntryOffset := TrieEntryOffset(tt.args.indexStart, tt.args.leafIndex)
+				trieEntryXOffset := trieEntryOffset + TrieDataSize(massifHeight)
 				if tt.wantExtraBytes[1] != nil {
-					gotExtended1 := tt.args.logData[trieEntryXOffset : trieEntryXOffset+ValueBytes]
+					gotExtended1 := testData[trieEntryXOffset : trieEntryXOffset+ValueBytes]
 					assert.Equal(t, tt.wantExtraBytes[1][:32], gotExtended1)
 				}
 
 				if len(tt.wantExtraBytes) > 2 && tt.wantExtraBytes[2] != nil {
-					gotExtended2 := tt.args.logData[trieEntryXOffset+ValueBytes : trieEntryXOffset+ValueBytes*2]
+					gotExtended2 := testData[trieEntryXOffset+ValueBytes : trieEntryXOffset+ValueBytes*2]
 					assert.Equal(t, tt.wantExtraBytes[2][:32], gotExtended2)
 				}
 			}
 
 			// Verify adjacent entries are not corrupted
-			// The entry at trieIndex*2 will be overwritten by extended bytes, so we don't check it
-			gotBefore := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex-1)
-			if tt.args.leafIndex-1 == 0 {
-				assert.Equal(t, b64zero[:32], gotBefore)
-			} else {
-				assert.Equal(t, b64one[:32], gotBefore)
+			// Extended bytes are in a separate storage area, so adjacent entries should be unchanged
+			if tt.args.leafIndex > 0 {
+				gotBefore := GetTrieKey(testData, tt.args.indexStart, tt.args.leafIndex-1)
+				if tt.args.leafIndex-1 == 0 {
+					assert.Equal(t, b64zero[:32], gotBefore)
+				} else {
+					assert.Equal(t, b64one[:32], gotBefore)
+				}
 			}
 
-			// Check entry after, but skip if it's the one being overwritten by extended bytes
-			if !tt.verifyExtended || tt.args.leafIndex*2 != tt.args.leafIndex+1 {
-				gotAfter := GetTrieKey(tt.args.logData, tt.args.indexStart, tt.args.leafIndex+1)
-				assert.Equal(t, b64two[:32], gotAfter)
+			// Check entry after - extended bytes are in separate storage, so this should be unchanged
+			gotAfter := GetTrieKey(testData, tt.args.indexStart, tt.args.leafIndex+1)
+			// Determine expected key based on leafIndex
+			var expectedAfter []byte
+			if tt.args.leafIndex == 0 {
+				expectedAfter = b64one[:32] // Entry at index 1
+			} else {
+				expectedAfter = b64two[:32] // Entry at index 2
 			}
+			assert.Equal(t, expectedAfter, gotAfter)
 		})
 	}
 }


### PR DESCRIPTION

When trieIndex was 0 and extended bytes were provided, the function used trieIndex * 2 = 0 as the offset for extended bytes. This caused extended bytes to overwrite the entry's trieKey and idTimestamp that were just written at the same location, completely corrupting the entry.

The fix uses trieEntryOffset + TrieDataSize(massifHeight) to place extended bytes in the dedicated extended storage area at the same relative position as the entry. This approach:
- Uses the actual allocated size (TrieDataSize) instead of a formula
- Places extended bytes in the extended storage area (second half of the double-allocated space)
- Works correctly for all trieIndex values including 0

Changes:
- Add massifHeight parameter to SetTrieEntryExtra (as first parameter)
- Update extended bytes offset calculation to use TrieDataSize
- Update all call sites to pass massifHeight
- Add test case for trieIndex=0 with extended bytes
- Extend test data to accommodate extended storage area

All tests pass, including integration tests in go-merklelog-azure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `SetTrieEntryExtra` to accept `massifHeight` and write extended bytes at `trieEntryOffset + TrieDataSize`, updating call sites and tests (including index 0 case) to prevent overwriting entries.
> 
> - **Trie entry handling**:
>   - Change `SetTrieEntryExtra` signature to `SetTrieEntryExtra(massifHeight, trieData, indexStart, trieIndex, ...)`.
>   - Compute extended bytes offset as `trieEntryOffset + TrieDataSize(massifHeight)` (instead of `trieIndex*2`), placing data in extended storage.
>   - Update caller in `massifs/massifcontext.go` to pass `mc.Start.MassifHeight`.
> - **Tests**:
>   - Extend `TestSetTrieEntryExtra` to allocate enough space for extended storage and verify writes at new offsets.
>   - Add case for `trieIndex=0` ensuring extended bytes no longer overwrite the entry.
>   - Refactor tests to use fresh buffers per case and confirm adjacent entries remain unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6dd5f49cf8bb21465c461392adb093d4040fd898. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->